### PR TITLE
Block outline and pick block changes

### DIFF
--- a/src/main/java/mmmfrieddough/craftpilot/config/ModConfig.java
+++ b/src/main/java/mmmfrieddough/craftpilot/config/ModConfig.java
@@ -3,8 +3,9 @@ package mmmfrieddough.craftpilot.config;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry.Category;
-import me.shedaniel.autoconfig.annotation.ConfigEntry.Gui.TransitiveObject;
+import me.shedaniel.autoconfig.annotation.ConfigEntry.ColorPicker;
 import me.shedaniel.autoconfig.annotation.ConfigEntry.Gui.Tooltip;
+import me.shedaniel.autoconfig.annotation.ConfigEntry.Gui.TransitiveObject;
 
 @Config(name = mmmfrieddough.craftpilot.Reference.MOD_ID)
 public class ModConfig implements ConfigData {
@@ -50,7 +51,12 @@ public class ModConfig implements ConfigData {
         @Tooltip
         public float blockPlacementOpacity = 0.8f;
         @Tooltip
-        public float blockOutlineOpacity = 0.2f;
+        public float blockOutlineOpacity = 0.4f;
+        @Tooltip
+        @ColorPicker
+        public int normalOutlineColor = 0x00FFFF; // Regular cyan
+        @Tooltip
+        @ColorPicker
+        public int targetedOutlineColor = 0x009FFF; // Blueish cyan
     }
-
 }

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
@@ -15,6 +15,7 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.resource.featuretoggle.FeatureSet;
+import net.minecraft.util.hit.HitResult;
 
 /**
  * Mixin to handle ghost block interactions in the Minecraft client.
@@ -33,9 +34,10 @@ public class MinecraftClientMixin {
         FeatureSet enabledFeatures = client.player.getWorld().getEnabledFeatures();
         boolean creativeMode = client.interactionManager.getCurrentGameMode().isCreative();
         PlayerInventory inventory = client.player.getInventory();
+        HitResult vanillaTarget = client.crosshairTarget;
 
         if (GhostBlockService.handleGhostBlockPick(worldManager, camera, reach, enabledFeatures, creativeMode,
-                inventory)) {
+                inventory, vanillaTarget)) {
             ci.cancel();
         }
     }
@@ -48,8 +50,9 @@ public class MinecraftClientMixin {
         Camera camera = client.gameRenderer.getCamera();
         double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
         ClientPlayerEntity player = client.player;
+        HitResult vanillaTarget = client.crosshairTarget;
 
-        if (GhostBlockService.handleGhostBlockBreak(worldManager, camera, reach, player)) {
+        if (GhostBlockService.handleGhostBlockBreak(worldManager, camera, reach, player, vanillaTarget)) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
@@ -12,11 +12,8 @@ import mmmfrieddough.craftpilot.world.IWorldManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.client.render.Camera;
-import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.resource.featuretoggle.FeatureSet;
-import net.minecraft.util.hit.HitResult;
 
 /**
  * Mixin to handle ghost block interactions in the Minecraft client.
@@ -28,18 +25,13 @@ public class MinecraftClientMixin {
     @Inject(method = "doItemPick", at = @At("HEAD"), cancellable = true)
     private void onDoItemPick(CallbackInfo ci) {
         // Extract necessary information
-        IWorldManager worldManager = CraftPilot.getInstance().getWorldManager();
         MinecraftClient client = MinecraftClient.getInstance();
-        Camera camera = client.gameRenderer.getCamera();
-        double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
         FeatureSet enabledFeatures = client.player.getWorld().getEnabledFeatures();
         boolean creativeMode = client.interactionManager.getCurrentGameMode().isCreative();
         PlayerInventory inventory = client.player.getInventory();
-        HitResult vanillaTarget = client.crosshairTarget;
         ClientPlayNetworkHandler networkHandler = client.getNetworkHandler();
 
-        if (GhostBlockService.handleGhostBlockPick(worldManager, camera, reach, enabledFeatures, creativeMode,
-                inventory, vanillaTarget, networkHandler)) {
+        if (GhostBlockService.handleGhostBlockPick(enabledFeatures, creativeMode, inventory, networkHandler)) {
             ci.cancel();
         }
     }
@@ -49,12 +41,9 @@ public class MinecraftClientMixin {
         // Extract necessary information
         IWorldManager worldManager = CraftPilot.getInstance().getWorldManager();
         MinecraftClient client = MinecraftClient.getInstance();
-        Camera camera = client.gameRenderer.getCamera();
-        double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
         ClientPlayerEntity player = client.player;
-        HitResult vanillaTarget = client.crosshairTarget;
 
-        if (GhostBlockService.handleGhostBlockBreak(worldManager, camera, reach, player, vanillaTarget)) {
+        if (GhostBlockService.handleGhostBlockBreak(worldManager, player)) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
@@ -6,16 +6,13 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import mmmfrieddough.craftpilot.CraftPilot;
 import mmmfrieddough.craftpilot.service.GhostBlockService;
-import mmmfrieddough.craftpilot.service.GhostBlockService.GhostBlockTarget;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.Camera;
 import net.minecraft.entity.attribute.EntityAttributes;
-import net.minecraft.util.Hand;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.resource.featuretoggle.FeatureSet;
 
 /**
  * Mixin to handle ghost block interactions in the Minecraft client.
@@ -23,54 +20,32 @@ import net.minecraft.util.math.Vec3d;
  */
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
+
     @Inject(method = "doItemPick", at = @At("HEAD"), cancellable = true)
     private void onDoItemPick(CallbackInfo ci) {
+        // Extract necessary information
         MinecraftClient client = MinecraftClient.getInstance();
-        GhostBlockTarget target = getGhostBlockTarget();
-        if (target == null) {
-            return;
-        }
+        Camera camera = client.gameRenderer.getCamera();
+        double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
+        FeatureSet enabledFeatures = client.player.getWorld().getEnabledFeatures();
+        boolean creativeMode = client.interactionManager.getCurrentGameMode().isCreative();
+        PlayerInventory inventory = client.player.getInventory();
 
-        // Handle picking up the ghost block
-        GhostBlockService.pickGhostBlock(client, target.state());
+        if (GhostBlockService.handleGhostBlockPick(camera, reach, enabledFeatures, creativeMode, inventory)) {
+            ci.cancel();
+        }
     }
 
     @Inject(method = "doAttack", at = @At("HEAD"), cancellable = true)
     private void onDoAttack(CallbackInfoReturnable<Boolean> cir) {
+        // Extract necessary information
         MinecraftClient client = MinecraftClient.getInstance();
-        GhostBlockTarget target = getGhostBlockTarget();
-        if (target == null) {
-            return;
-        }
-
-        // Handle breaking the ghost block
-        CraftPilot.getInstance().getWorldManager().clearBlockState(target.pos());
-        client.player.swingHand(Hand.MAIN_HAND);
-        cir.setReturnValue(true);
-    }
-
-    /**
-     * Gets the ghost block the player is currently looking at
-     * 
-     * @return Target information, or null if no valid target
-     */
-    private GhostBlockTarget getGhostBlockTarget() {
-        MinecraftClient client = MinecraftClient.getInstance();
-        if (client.player == null || client.world == null || client.gameRenderer == null) {
-            return null;
-        }
-
         Camera camera = client.gameRenderer.getCamera();
-        Vec3d lookVec = Vec3d.fromPolar(camera.getPitch(), camera.getYaw());
         double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
+        ClientPlayerEntity player = client.player;
 
-        BlockPos targetPos = GhostBlockService.findTargetedGhostBlock(
-                CraftPilot.getInstance().getWorldManager().getGhostBlocks(), camera.getPos(), lookVec, reach);
-        if (targetPos == null) {
-            return null;
+        if (GhostBlockService.handleGhostBlockBreak(camera, reach, player)) {
+            cir.setReturnValue(true);
         }
-
-        BlockState ghostState = CraftPilot.getInstance().getWorldManager().getGhostBlocks().get(targetPos);
-        return new GhostBlockTarget(targetPos, ghostState);
     }
 }

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
@@ -6,7 +6,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import mmmfrieddough.craftpilot.CraftPilot;
 import mmmfrieddough.craftpilot.service.GhostBlockService;
+import mmmfrieddough.craftpilot.world.IWorldManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.Camera;
@@ -24,6 +26,7 @@ public class MinecraftClientMixin {
     @Inject(method = "doItemPick", at = @At("HEAD"), cancellable = true)
     private void onDoItemPick(CallbackInfo ci) {
         // Extract necessary information
+        IWorldManager worldManager = CraftPilot.getInstance().getWorldManager();
         MinecraftClient client = MinecraftClient.getInstance();
         Camera camera = client.gameRenderer.getCamera();
         double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
@@ -31,7 +34,8 @@ public class MinecraftClientMixin {
         boolean creativeMode = client.interactionManager.getCurrentGameMode().isCreative();
         PlayerInventory inventory = client.player.getInventory();
 
-        if (GhostBlockService.handleGhostBlockPick(camera, reach, enabledFeatures, creativeMode, inventory)) {
+        if (GhostBlockService.handleGhostBlockPick(worldManager, camera, reach, enabledFeatures, creativeMode,
+                inventory)) {
             ci.cancel();
         }
     }
@@ -39,12 +43,13 @@ public class MinecraftClientMixin {
     @Inject(method = "doAttack", at = @At("HEAD"), cancellable = true)
     private void onDoAttack(CallbackInfoReturnable<Boolean> cir) {
         // Extract necessary information
+        IWorldManager worldManager = CraftPilot.getInstance().getWorldManager();
         MinecraftClient client = MinecraftClient.getInstance();
         Camera camera = client.gameRenderer.getCamera();
         double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
         ClientPlayerEntity player = client.player;
 
-        if (GhostBlockService.handleGhostBlockBreak(camera, reach, player)) {
+        if (GhostBlockService.handleGhostBlockBreak(worldManager, camera, reach, player)) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/MinecraftClientMixin.java
@@ -10,6 +10,7 @@ import mmmfrieddough.craftpilot.CraftPilot;
 import mmmfrieddough.craftpilot.service.GhostBlockService;
 import mmmfrieddough.craftpilot.world.IWorldManager;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.Camera;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -35,9 +36,10 @@ public class MinecraftClientMixin {
         boolean creativeMode = client.interactionManager.getCurrentGameMode().isCreative();
         PlayerInventory inventory = client.player.getInventory();
         HitResult vanillaTarget = client.crosshairTarget;
+        ClientPlayNetworkHandler networkHandler = client.getNetworkHandler();
 
         if (GhostBlockService.handleGhostBlockPick(worldManager, camera, reach, enabledFeatures, creativeMode,
-                inventory, vanillaTarget)) {
+                inventory, vanillaTarget, networkHandler)) {
             ci.cancel();
         }
     }

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/WorldRendererMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/WorldRendererMixin.java
@@ -68,15 +68,11 @@ public class WorldRendererMixin {
         // Apply the position matrix to align with world coordinates
         matrices.multiplyPositionMatrix(positionMatrix);
 
-        GhostBlockRenderService.renderGhostBlocks(
-                client, ghostBlocks, cameraPos, cameraX, cameraY, cameraZ,
-                renderDistance, config.rendering.blockPlacementOpacity,
-                matrices, immediate);
+        GhostBlockRenderService.renderGhostBlocks(client, ghostBlocks, cameraPos, cameraX, cameraY, cameraZ,
+                renderDistance, config.rendering.blockPlacementOpacity, matrices, immediate);
 
-        GhostBlockRenderService.renderBlockOutlines(
-                client, ghostBlocks, cameraPos, cameraX, cameraY, cameraZ,
-                renderDistance, config.rendering.blockOutlineOpacity,
-                matrices, immediate);
+        GhostBlockRenderService.renderBlockOutlines(client, ghostBlocks, cameraPos, cameraX, cameraY, cameraZ,
+                renderDistance, config.rendering, matrices, immediate);
 
         matrices.pop();
 

--- a/src/main/java/mmmfrieddough/craftpilot/mixin/WorldRendererMixin.java
+++ b/src/main/java/mmmfrieddough/craftpilot/mixin/WorldRendererMixin.java
@@ -27,33 +27,44 @@ import net.minecraft.client.util.ObjectAllocator;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.attribute.EntityAttributes;
-import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.profiler.Profilers;
 
 @Mixin(WorldRenderer.class)
 public class WorldRendererMixin {
+    @Inject(method = "render", at = @At("HEAD"))
+    private void onRenderStart(ObjectAllocator objectAllocator, RenderTickCounter renderTickCounter,
+            boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, Matrix4f positionMatrix,
+            Matrix4f projectionMatrix, CallbackInfo ci) {
+        Profilers.get().push("craftpilot_update_targetted_block");
+
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.player != null) {
+            double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
+            IWorldManager manager = CraftPilot.getInstance().getWorldManager();
+            GhostBlockService.updateCurrentTarget(manager, camera, reach, client.crosshairTarget);
+        }
+
+        Profilers.get().pop();
+    }
+
     @Inject(method = "render", at = @At("RETURN"))
     private void onRender(ObjectAllocator objectAllocator, RenderTickCounter renderTickCounter,
             boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer,
             Matrix4f positionMatrix, Matrix4f projectionMatrix, CallbackInfo ci) {
-        Profilers.get().push("craftpilot_render");
+        Profilers.get().push("craftpilot_render_blocks");
 
-        MinecraftClient client = MinecraftClient.getInstance();
         IWorldManager manager = CraftPilot.getInstance().getWorldManager();
         Map<BlockPos, BlockState> ghostBlocks = manager.getGhostBlocks();
 
         // Early return if no blocks to render
         if (ghostBlocks.isEmpty()) {
+            Profilers.get().pop();
             return;
         }
 
+        MinecraftClient client = MinecraftClient.getInstance();
         ModConfig config = CraftPilot.getConfig();
-        BlockPos cameraPos = camera.getBlockPos();
-        double cameraX = camera.getPos().x;
-        double cameraY = camera.getPos().y;
-        double cameraZ = camera.getPos().z;
         int renderDistance = config.rendering.renderDistance;
 
         // Create vertex consumer once
@@ -68,11 +79,11 @@ public class WorldRendererMixin {
         // Apply the position matrix to align with world coordinates
         matrices.multiplyPositionMatrix(positionMatrix);
 
-        GhostBlockRenderService.renderGhostBlocks(client, ghostBlocks, cameraPos, cameraX, cameraY, cameraZ,
-                renderDistance, config.rendering.blockPlacementOpacity, matrices, immediate);
+        GhostBlockRenderService.renderGhostBlocks(client, ghostBlocks, camera, renderDistance,
+                config.rendering.blockPlacementOpacity, matrices, immediate);
 
-        GhostBlockRenderService.renderBlockOutlines(client, ghostBlocks, cameraPos, cameraX, cameraY, cameraZ,
-                renderDistance, config.rendering, matrices, immediate);
+        GhostBlockRenderService.renderBlockOutlines(client, ghostBlocks, camera, renderDistance, config.rendering,
+                matrices, immediate);
 
         matrices.pop();
 
@@ -85,27 +96,7 @@ public class WorldRendererMixin {
     @Inject(method = "drawBlockOutline", at = @At("HEAD"), cancellable = true)
     private void onDrawBlockOutline(MatrixStack matrices, VertexConsumer vertexConsumer, Entity entity, double cameraX,
             double cameraY, double cameraZ, BlockPos blockPos, BlockState blockState, int i, CallbackInfo ci) {
-        // Get ghost blocks
-        IWorldManager manager = CraftPilot.getInstance().getWorldManager();
-        Map<BlockPos, BlockState> ghostBlocks = manager.getGhostBlocks();
-
-        // Early return if no blocks to check
-        if (ghostBlocks.isEmpty()) {
-            return;
-        }
-
-        // Check if there's a ghost block in front of the target
-        MinecraftClient client = MinecraftClient.getInstance();
-        Camera camera = client.gameRenderer.getCamera();
-        Vec3d cameraPos = camera.getPos();
-        Vec3d lookVec = Vec3d.fromPolar(camera.getPitch(), camera.getYaw());
-        double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
-        HitResult vanillaTarget = client.crosshairTarget;
-
-        BlockPos ghostTarget = GhostBlockService.findTargetedGhostBlock(ghostBlocks, cameraPos, lookVec, reach,
-                vanillaTarget);
-        if (ghostTarget != null) {
-            // If there's a ghost block being targeted, cancel the vanilla outline
+        if (GhostBlockService.getCurrentTarget() != null) {
             ci.cancel();
         }
     }

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockRenderService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockRenderService.java
@@ -6,14 +6,18 @@ import org.lwjgl.opengl.GL11;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
+import mmmfrieddough.craftpilot.config.ModConfig.Rendering;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.VertexRendering;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 
 public final class GhostBlockRenderService {
@@ -76,41 +80,74 @@ public final class GhostBlockRenderService {
             double cameraY,
             double cameraZ,
             int renderDistance,
-            float opacity,
+            Rendering config,
             MatrixStack matrices,
             VertexConsumerProvider.Immediate immediate) {
 
-        RenderSystem.setShaderColor(0.0f, 1.0f, 1.0f, opacity);
-        RenderSystem.lineWidth(2.0f);
+        // Get currently targeted ghost block
+        Camera camera = client.gameRenderer.getCamera();
+        Vec3d camPos = camera.getPos();
+        Vec3d lookVec = camera.getFocusedEntity().getRotationVec(1.0f);
+        double reach = client.player.getAttributeValue(EntityAttributes.BLOCK_INTERACTION_RANGE);
+        BlockPos targetedBlock = GhostBlockService.findTargetedGhostBlock(
+                ghostBlocks, camPos, lookVec, reach, client.crosshairTarget);
 
-        // Address Z-fighting issues with vanilla block outlines
         RenderSystem.enableDepthTest();
         RenderSystem.depthFunc(GL11.GL_LESS);
-        RenderSystem.polygonOffset(-1.0f, -3.0f);
+        RenderSystem.lineWidth(2.0f);
 
+        // First pass: render non-targeted blocks
+        RenderSystem.polygonOffset(-2.0f, -8.0f);
         RenderSystem.enablePolygonOffset();
 
-        VertexConsumer lineVertices = immediate.getBuffer(RenderLayer.getLines());
+        VertexConsumer normalVertices = immediate.getBuffer(RenderLayer.getLines());
+
+        int alpha = (int) (config.blockOutlineOpacity * 255.0f);
+        int normalColor = (alpha << 24) | config.normalOutlineColor;
 
         for (Map.Entry<BlockPos, BlockState> entry : ghostBlocks.entrySet()) {
             BlockPos pos = entry.getKey();
-            if (pos.isWithinDistance(cameraPos, renderDistance)) {
+            if (!pos.equals(targetedBlock) && pos.isWithinDistance(cameraPos, renderDistance)) {
                 VoxelShape shape = entry.getValue().getOutlineShape(client.world, pos);
-
                 shape.forEachBox((minX, minY, minZ, maxX, maxY, maxZ) -> {
                     VertexRendering.drawOutline(
                             matrices,
-                            lineVertices,
+                            normalVertices,
                             shape,
                             pos.getX() - cameraX,
                             pos.getY() - cameraY,
                             pos.getZ() - cameraZ,
-                            0xFF66FFFF); // Cyan color in ARGB format
+                            normalColor);
                 });
             }
         }
 
         immediate.draw();
+
+        // Second pass: render targeted block
+        if (targetedBlock != null && targetedBlock.isWithinDistance(cameraPos, renderDistance)) {
+            // Get fresh buffer for second pass
+            VertexConsumer targetedVertices = immediate.getBuffer(RenderLayer.getLines());
+
+            // Use less offset to render on top
+            RenderSystem.polygonOffset(-3.0f, -10.0f);
+
+            BlockState state = ghostBlocks.get(targetedBlock);
+            VoxelShape shape = state.getOutlineShape(client.world, targetedBlock);
+            int targetedColor = (alpha << 24) | config.targetedOutlineColor;
+            shape.forEachBox((minX, minY, minZ, maxX, maxY, maxZ) -> {
+                VertexRendering.drawOutline(
+                        matrices,
+                        targetedVertices,
+                        shape,
+                        targetedBlock.getX() - cameraX,
+                        targetedBlock.getY() - cameraY,
+                        targetedBlock.getZ() - cameraZ,
+                        targetedColor);
+            });
+
+            immediate.draw();
+        }
 
         RenderSystem.polygonOffset(0.0f, 0.0f);
         RenderSystem.disablePolygonOffset();

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockRenderService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockRenderService.java
@@ -2,6 +2,8 @@ package mmmfrieddough.craftpilot.service;
 
 import java.util.Map;
 
+import org.lwjgl.opengl.GL11;
+
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import net.minecraft.block.BlockState;
@@ -81,6 +83,13 @@ public final class GhostBlockRenderService {
         RenderSystem.setShaderColor(0.0f, 1.0f, 1.0f, opacity);
         RenderSystem.lineWidth(2.0f);
 
+        // Address Z-fighting issues with vanilla block outlines
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthFunc(GL11.GL_LESS);
+        RenderSystem.polygonOffset(-1.0f, -3.0f);
+
+        RenderSystem.enablePolygonOffset();
+
         VertexConsumer lineVertices = immediate.getBuffer(RenderLayer.getLines());
 
         for (Map.Entry<BlockPos, BlockState> entry : ghostBlocks.entrySet()) {
@@ -102,5 +111,9 @@ public final class GhostBlockRenderService {
         }
 
         immediate.draw();
+
+        RenderSystem.polygonOffset(0.0f, 0.0f);
+        RenderSystem.disablePolygonOffset();
+        RenderSystem.depthFunc(GL11.GL_LEQUAL);
     }
 }

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
@@ -32,17 +32,14 @@ public final class GhostBlockService {
      * Handles ghost block picking interaction by selecting or adding the targeted
      * block to inventory
      * 
-     * @param worldManager    Manager handling ghost block state and interactions
-     * @param camera          Camera instance providing position and view direction
-     * @param reach           Maximum interaction range in blocks
      * @param enabledFeatures Set of enabled game features
      * @param creativeMode    Whether the player is in creative mode
      * @param inventory       Player's inventory
+     * @param networkHandler  Network handler for sending inventory updates
      * @return true if a ghost block was successfully picked, false otherwise
      */
-    public static boolean handleGhostBlockPick(IWorldManager worldManager, Camera camera, double reach,
-            FeatureSet enabledFeatures, boolean creativeMode, PlayerInventory inventory, HitResult vanillaTarget,
-            ClientPlayNetworkHandler networkHandler) {
+    public static boolean handleGhostBlockPick(FeatureSet enabledFeatures, boolean creativeMode,
+            PlayerInventory inventory, ClientPlayNetworkHandler networkHandler) {
         GhostBlockTarget target = getCurrentTarget();
         if (target == null) {
             return false;
@@ -56,13 +53,10 @@ public final class GhostBlockService {
      * Handles ghost block breaking interaction by removing the targeted ghost block
      * 
      * @param worldManager Manager handling ghost block state and interactions
-     * @param camera       Camera instance providing position and view direction
-     * @param reach        Maximum interaction range in blocks
      * @param player       The client player entity performing the break action
      * @return true if a ghost block was successfully broken, false otherwise
      */
-    public static boolean handleGhostBlockBreak(IWorldManager worldManager, Camera camera, double reach,
-            ClientPlayerEntity player, HitResult vanillaTarget) {
+    public static boolean handleGhostBlockBreak(IWorldManager worldManager, ClientPlayerEntity player) {
         GhostBlockTarget target = getCurrentTarget();
         if (target == null) {
             return false;
@@ -77,11 +71,13 @@ public final class GhostBlockService {
      * Finds the nearest ghost block along the player's line of sight using
      * raycasting
      * 
-     * @param ghostBlocks Map of ghost block positions to their corresponding block
-     *                    states
-     * @param cameraPos   Starting position for the raycast
-     * @param lookVec     Direction vector of the player's view
-     * @param reach       Maximum reach distance in blocks
+     * @param ghostBlocks   Map of ghost block positions to their corresponding
+     *                      block
+     *                      states
+     * @param cameraPos     Starting position for the raycast
+     * @param lookVec       Direction vector of the player's view
+     * @param reach         Maximum reach distance in blocks
+     * @param vanillaTarget The vanilla target result from the client
      * @return The position of the nearest ghost block hit by the raycast, or null
      *         if none found
      */
@@ -124,6 +120,7 @@ public final class GhostBlockService {
      * @param creativeMode    Whether the player is in creative mode for inventory
      *                        manipulation
      * @param inventory       Player's inventory to modify
+     * @param networkHandler  Network handler for sending inventory updates
      */
     private static void pickGhostBlock(BlockState state, FeatureSet enabledFeatures, boolean creativeMode,
             PlayerInventory inventory, ClientPlayNetworkHandler networkHandler) {
@@ -156,9 +153,10 @@ public final class GhostBlockService {
     /**
      * Gets the ghost block the player is currently targeting
      * 
-     * @param worldManager Manager handling ghost block state and interactions
-     * @param camera       Camera instance providing position and view direction
-     * @param reach        Maximum interaction range in blocks
+     * @param worldManager  Manager handling ghost block state and interactions
+     * @param camera        Camera instance providing position and view direction
+     * @param reach         Maximum interaction range in blocks
+     * @param vanillaTarget The vanilla target result from the client
      * @return A GhostBlockTarget containing the position and state of the targeted
      *         block,
      *         or null if no ghost block is being targeted

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
@@ -3,10 +3,14 @@ package mmmfrieddough.craftpilot.service;
 import java.util.Map;
 import java.util.Optional;
 
+import mmmfrieddough.craftpilot.CraftPilot;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.render.Camera;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.resource.featuretoggle.FeatureSet;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
@@ -20,16 +24,56 @@ public final class GhostBlockService {
     }
 
     /**
+     * Handles ghost block picking interaction
+     * 
+     * @param camera          Camera instance providing position and view direction
+     * @param reach           Maximum interaction range
+     * @param enabledFeatures Set of enabled game features
+     * @param creativeMode    Whether the player is in creative mode
+     * @param inventory       Player's inventory
+     * @return true if a ghost block was picked, false otherwise
+     */
+    public static boolean handleGhostBlockPick(Camera camera, double reach, FeatureSet enabledFeatures,
+            boolean creativeMode, PlayerInventory inventory) {
+        GhostBlockTarget target = getGhostBlockTarget(camera, reach);
+        if (target == null) {
+            return false;
+        }
+
+        pickGhostBlock(target.state(), enabledFeatures, creativeMode, inventory);
+        return true;
+    }
+
+    /**
+     * Handles ghost block breaking interaction
+     * 
+     * @param camera Camera instance providing position and view direction
+     * @param reach  Maximum interaction range
+     * @param player The client player entity
+     * @return true if a ghost block was broken, false otherwise
+     */
+    public static boolean handleGhostBlockBreak(Camera camera, double reach, ClientPlayerEntity player) {
+        GhostBlockTarget target = getGhostBlockTarget(camera, reach);
+        if (target == null) {
+            return false;
+        }
+
+        CraftPilot.getInstance().getWorldManager().clearBlockState(target.pos());
+        player.swingHand(Hand.MAIN_HAND);
+        return true;
+    }
+
+    /**
      * Finds the nearest ghost block along the player's line of sight
      * 
-     * @param ghostBlocks Map of ghost blocks
+     * @param ghostBlocks Map of ghost blocks and their states
      * @param cameraPos   Starting position for raytrace
      * @param lookVec     Direction vector
      * @param reach       Maximum reach distance
      * @return The nearest ghost block position, or null if none found
      */
-    public static BlockPos findTargetedGhostBlock(Map<BlockPos, BlockState> ghostBlocks, Vec3d cameraPos, Vec3d lookVec,
-            double reach) {
+    private static BlockPos findTargetedGhostBlock(Map<BlockPos, BlockState> ghostBlocks, Vec3d cameraPos,
+            Vec3d lookVec, double reach) {
         if (ghostBlocks.isEmpty()) {
             return null;
         }
@@ -56,33 +100,58 @@ public final class GhostBlockService {
     /**
      * Picks the ghost block at the targeted position
      * 
-     * @param client Minecraft client
-     * @param state  Block state to pick
+     * @param state           Block state to pick
+     * @param enabledFeatures Set of enabled game features
+     * @param creativeMode    Whether the player is in creative mode
+     * @param inventory       Player's inventory
      */
-    public static void pickGhostBlock(MinecraftClient client, BlockState state) {
+    private static void pickGhostBlock(BlockState state, FeatureSet enabledFeatures, boolean creativeMode,
+            PlayerInventory inventory) {
         // Get item as stack
         ItemStack itemStack = state.getBlock().asItem().getDefaultStack();
 
         if (!itemStack.isEmpty()) {
             // Check if item is enabled
-            if (itemStack.isItemEnabled(client.player.getWorld().getEnabledFeatures())) {
-                PlayerInventory playerInventory = client.player.getInventory();
-
+            if (itemStack.isItemEnabled(enabledFeatures)) {
                 // Check if item is already in inventory
-                int i = playerInventory.getSlotWithStack(itemStack);
+                int i = inventory.getSlotWithStack(itemStack);
                 if (i != -1) {
                     // Select slot if in hotbar, otherwise swap with hotbar
                     if (PlayerInventory.isValidHotbarIndex(i)) {
-                        playerInventory.selectedSlot = i;
+                        inventory.selectedSlot = i;
                     } else {
-                        playerInventory.swapSlotWithHotbar(i);
+                        inventory.swapSlotWithHotbar(i);
                     }
-                } else if (client.player.isInCreativeMode()) {
+                } else if (creativeMode) {
                     // Add item to inventory
-                    playerInventory.swapStackWithHotbar(itemStack);
+                    inventory.swapStackWithHotbar(itemStack);
                     itemStack.setBobbingAnimationTime(5);
                 }
             }
         }
+    }
+
+    /**
+     * Gets the ghost block the player is currently looking at
+     * 
+     * @param camera Camera instance providing position and view direction
+     * @param reach  Maximum interaction range
+     * @return A GhostBlockTarget containing the position and state of the targeted
+     *         block, or null if none found
+     */
+    private static GhostBlockTarget getGhostBlockTarget(Camera camera, double reach) {
+        Vec3d lookVec = Vec3d.fromPolar(camera.getPitch(), camera.getYaw());
+
+        BlockPos targetPos = findTargetedGhostBlock(
+                CraftPilot.getInstance().getWorldManager().getGhostBlocks(),
+                camera.getPos(),
+                lookVec,
+                reach);
+        if (targetPos == null) {
+            return null;
+        }
+
+        BlockState ghostState = CraftPilot.getInstance().getWorldManager().getGhostBlocks().get(targetPos);
+        return new GhostBlockTarget(targetPos, ghostState);
     }
 }

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
@@ -4,10 +4,12 @@ import java.util.Map;
 
 import mmmfrieddough.craftpilot.world.IWorldManager;
 import net.minecraft.block.BlockState;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.Camera;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
 import net.minecraft.resource.featuretoggle.FeatureSet;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -39,13 +41,14 @@ public final class GhostBlockService {
      * @return true if a ghost block was successfully picked, false otherwise
      */
     public static boolean handleGhostBlockPick(IWorldManager worldManager, Camera camera, double reach,
-            FeatureSet enabledFeatures, boolean creativeMode, PlayerInventory inventory, HitResult vanillaTarget) {
+            FeatureSet enabledFeatures, boolean creativeMode, PlayerInventory inventory, HitResult vanillaTarget,
+            ClientPlayNetworkHandler networkHandler) {
         GhostBlockTarget target = getCurrentTarget();
         if (target == null) {
             return false;
         }
 
-        pickGhostBlock(target.state(), enabledFeatures, creativeMode, inventory);
+        pickGhostBlock(target.state(), enabledFeatures, creativeMode, inventory, networkHandler);
         return true;
     }
 
@@ -123,7 +126,7 @@ public final class GhostBlockService {
      * @param inventory       Player's inventory to modify
      */
     private static void pickGhostBlock(BlockState state, FeatureSet enabledFeatures, boolean creativeMode,
-            PlayerInventory inventory) {
+            PlayerInventory inventory, ClientPlayNetworkHandler networkHandler) {
         // Get item as stack
         ItemStack itemStack = state.getBlock().asItem().getDefaultStack();
 
@@ -143,6 +146,8 @@ public final class GhostBlockService {
                     // Add item to inventory
                     inventory.swapStackWithHotbar(itemStack);
                     itemStack.setBobbingAnimationTime(5);
+                    networkHandler
+                            .sendPacket(new CreativeInventoryActionC2SPacket(36 + inventory.selectedSlot, itemStack));
                 }
             }
         }

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
@@ -20,6 +20,8 @@ public final class GhostBlockService {
     public record GhostBlockTarget(BlockPos pos, BlockState state) {
     }
 
+    private static GhostBlockTarget currentTarget = null;
+
     // Prevent instantiation
     private GhostBlockService() {
     }
@@ -38,7 +40,7 @@ public final class GhostBlockService {
      */
     public static boolean handleGhostBlockPick(IWorldManager worldManager, Camera camera, double reach,
             FeatureSet enabledFeatures, boolean creativeMode, PlayerInventory inventory, HitResult vanillaTarget) {
-        GhostBlockTarget target = getGhostBlockTarget(worldManager, camera, reach, vanillaTarget);
+        GhostBlockTarget target = getCurrentTarget();
         if (target == null) {
             return false;
         }
@@ -58,7 +60,7 @@ public final class GhostBlockService {
      */
     public static boolean handleGhostBlockBreak(IWorldManager worldManager, Camera camera, double reach,
             ClientPlayerEntity player, HitResult vanillaTarget) {
-        GhostBlockTarget target = getGhostBlockTarget(worldManager, camera, reach, vanillaTarget);
+        GhostBlockTarget target = getCurrentTarget();
         if (target == null) {
             return false;
         }
@@ -171,5 +173,18 @@ public final class GhostBlockService {
 
         BlockState ghostState = worldManager.getGhostBlocks().get(targetPos);
         return new GhostBlockTarget(targetPos, ghostState);
+    }
+
+    public static void updateCurrentTarget(IWorldManager worldManager, Camera camera, double reach,
+            HitResult vanillaTarget) {
+        currentTarget = getGhostBlockTarget(worldManager, camera, reach, vanillaTarget);
+    }
+
+    public static GhostBlockTarget getCurrentTarget() {
+        return currentTarget;
+    }
+
+    public static BlockPos getCurrentTargetPos() {
+        return currentTarget != null ? currentTarget.pos() : null;
     }
 }

--- a/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
+++ b/src/main/java/mmmfrieddough/craftpilot/service/GhostBlockService.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import mmmfrieddough.craftpilot.world.IWorldManager;
-import mmmfrieddough.craftpilot.world.WorldManager;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.Camera;

--- a/src/main/resources/assets/craftpilot/lang/en_us.json
+++ b/src/main/resources/assets/craftpilot/lang/en_us.json
@@ -28,5 +28,9 @@
     "text.autoconfig.craftpilot.option.rendering.blockPlacementOpacity": "Block Placement Opacity",
     "text.autoconfig.craftpilot.option.rendering.blockPlacementOpacity.@Tooltip": "The opacity of the block placement",
     "text.autoconfig.craftpilot.option.rendering.blockOutlineOpacity": "Block Outline Opacity",
-    "text.autoconfig.craftpilot.option.rendering.blockOutlineOpacity.@Tooltip": "The opacity of the block outline"
+    "text.autoconfig.craftpilot.option.rendering.blockOutlineOpacity.@Tooltip": "The opacity of the block outline",
+    "text.autoconfig.craftpilot.option.rendering.normalOutlineColor": "Normal Outline Color",
+    "text.autoconfig.craftpilot.option.rendering.normalOutlineColor.@Tooltip": "The color of the outline on the suggested blocks",
+    "text.autoconfig.craftpilot.option.rendering.targetedOutlineColor": "Targeted Outline Color",
+    "text.autoconfig.craftpilot.option.rendering.targetedOutlineColor.@Tooltip": "The color of the outline on the targeted suggested block"
 }

--- a/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
+++ b/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
@@ -111,8 +111,8 @@ class GhostBlockServiceTest {
     class BasicPickingTests {
         @Test
         void givenNoGhostBlocks_whenPicking_thenNoAction() {
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -124,8 +124,8 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
             when(inventory.getSlotWithStack(stack)).thenReturn(-1);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertTrue(result);
             verify(inventory).swapStackWithHotbar(stack);
@@ -139,8 +139,8 @@ class GhostBlockServiceTest {
             // Looking straight up instead of ahead
             when(focusedEntity.getRotationVec(1.0f)).thenReturn(new Vec3d(0, 1, 0));
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -150,8 +150,8 @@ class GhostBlockServiceTest {
         void givenDistantGhostBlock_whenPicking_thenNoAction() {
             ghostBlocks.put(new BlockPos(10, 0, 0), state);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -166,8 +166,8 @@ class GhostBlockServiceTest {
 
             when(inventory.getSlotWithStack(stack)).thenReturn(-1);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertTrue(result);
             verify(inventory).swapStackWithHotbar(stack);
@@ -182,8 +182,8 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
             when(inventory.getSlotWithStack(stack)).thenReturn(0);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertTrue(result);
             assertEquals(0, inventory.selectedSlot);
@@ -196,8 +196,8 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
             when(inventory.getSlotWithStack(stack)).thenReturn(9);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertTrue(result);
             verify(inventory).swapSlotWithHotbar(9);
@@ -211,8 +211,8 @@ class GhostBlockServiceTest {
         void givenNegativeReach_whenPicking_thenNoAction() {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, -1.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, -1, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -223,8 +223,8 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
             when(stack.isItemEnabled(any())).thenReturn(false);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertTrue(result); // Method still returns true as block was found
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -235,8 +235,8 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
             when(stack.isEmpty()).thenReturn(true);
 
-            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget, networkHandler);
+            GhostBlockService.updateCurrentTarget(worldManager, camera, 5, vanillaTarget);
+            boolean result = GhostBlockService.handleGhostBlockPick(null, true, inventory, networkHandler);
 
             assertTrue(result); // Method still returns true as block was found
             verify(inventory, never()).swapStackWithHotbar(any());

--- a/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
+++ b/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
@@ -1,192 +1,194 @@
-package mmmfrieddough.craftpilot.service;
+// package mmmfrieddough.craftpilot.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+// import static org.junit.jupiter.api.Assertions.assertEquals;
+// import static org.junit.jupiter.api.Assertions.assertNull;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.ArgumentMatchers.anyInt;
+// import static org.mockito.Mockito.doReturn;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.Map;
+// import java.util.HashMap;
+// import java.util.Map;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
+// import org.junit.jupiter.api.BeforeAll;
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.extension.ExtendWith;
+// import org.mockito.Mock;
+// import org.mockito.junit.jupiter.MockitoExtension;
+// import org.mockito.junit.jupiter.MockitoSettings;
+// import org.mockito.quality.Strictness;
 
-import net.minecraft.Bootstrap;
-import net.minecraft.SharedConstants;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.resource.featuretoggle.FeatureSet;
-import net.minecraft.resource.featuretoggle.FeatureUniverse;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.World;
+// import net.minecraft.Bootstrap;
+// import net.minecraft.SharedConstants;
+// import net.minecraft.block.Block;
+// import net.minecraft.block.BlockState;
+// import net.minecraft.block.Blocks;
+// import net.minecraft.client.MinecraftClient;
+// import net.minecraft.client.network.ClientPlayerEntity;
+// import net.minecraft.entity.player.PlayerInventory;
+// import net.minecraft.item.Item;
+// import net.minecraft.item.ItemStack;
+// import net.minecraft.util.math.BlockPos;
+// import net.minecraft.util.math.Vec3d;
+// import net.minecraft.world.World;
 
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-class GhostBlockServiceTest {
+// @ExtendWith(MockitoExtension.class)
+// @MockitoSettings(strictness = Strictness.LENIENT)
+// class GhostBlockServiceTest {
 
-    @Mock
-    private MinecraftClient client;
-    @Mock
-    private ClientPlayerEntity player;
-    @Mock
-    private PlayerInventory inventory;
-    @Mock
-    private World world;
-    @Mock
-    private BlockState state;
-    @Mock
-    private Block block;
-    @Mock
-    private Item item;
-    @Mock
-    private ItemStack stack;
+// @Mock
+// private MinecraftClient client;
+// @Mock
+// private ClientPlayerEntity player;
+// @Mock
+// private PlayerInventory inventory;
+// @Mock
+// private World world;
+// @Mock
+// private BlockState state;
+// @Mock
+// private Block block;
+// @Mock
+// private Item item;
+// @Mock
+// private ItemStack stack;
 
-    @BeforeAll
-    static void init() {
-        SharedConstants.createGameVersion();
-        Bootstrap.initialize();
-    }
+// @BeforeAll
+// static void init() {
+// SharedConstants.createGameVersion();
+// Bootstrap.initialize();
+// }
 
-    @BeforeEach
-    void setUp() {
-        client.player = player;
-        doReturn(inventory).when(player).getInventory();
-        when(player.getWorld()).thenReturn(world);
-        when(world.getEnabledFeatures()).thenReturn(null);
-        when(state.getBlock()).thenReturn(block);
-        when(block.asItem()).thenReturn(item);
-        when(item.getDefaultStack()).thenReturn(stack);
-        when(stack.isEmpty()).thenReturn(false);
-        when(stack.isItemEnabled(any())).thenReturn(true);
-    }
+// @BeforeEach
+// void setUp() {
+// client.player = player;
+// doReturn(inventory).when(player).getInventory();
+// when(player.getWorld()).thenReturn(world);
+// when(world.getEnabledFeatures()).thenReturn(null);
+// when(state.getBlock()).thenReturn(block);
+// when(block.asItem()).thenReturn(item);
+// when(item.getDefaultStack()).thenReturn(stack);
+// when(stack.isEmpty()).thenReturn(false);
+// when(stack.isItemEnabled(any())).thenReturn(true);
+// }
 
-    @Test
-    void findTargetedGhostBlock_EmptyMap_ReturnsNull() {
-        Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-        Vec3d cameraPos = new Vec3d(0, 0, 0);
-        Vec3d lookVec = new Vec3d(1, 0, 0);
+// @Test
+// void pickBlock_EmptyMap_NoAction() {
+// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
+// Vec3d cameraPos = new Vec3d(0, 0, 0);
+// Vec3d lookVec = new Vec3d(1, 0, 0);
 
-        BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks, cameraPos, lookVec, 5.0);
+// GhostBlockService.handleGhostBlockPick(client);
 
-        assertNull(result);
-    }
+// assertNull(result);
+// }
 
-    @Test
-    void findTargetedGhostBlock_LookingDirectlyAtBlock_ReturnsBlock() {
-        Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-        BlockPos pos = new BlockPos(2, 1, 0);
-        BlockState stoneState = Blocks.STONE.getDefaultState();
-        ghostBlocks.put(pos, stoneState);
+// @Test
+// void findTargetedGhostBlock_LookingDirectlyAtBlock_ReturnsBlock() {
+// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
+// BlockPos pos = new BlockPos(2, 1, 0);
+// BlockState stoneState = Blocks.STONE.getDefaultState();
+// ghostBlocks.put(pos, stoneState);
 
-        Vec3d cameraPos = new Vec3d(0, 1, 0);
-        Vec3d lookVec = new Vec3d(1, 0, 0);
+// Vec3d cameraPos = new Vec3d(0, 1, 0);
+// Vec3d lookVec = new Vec3d(1, 0, 0);
 
-        BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks, cameraPos, lookVec, 5.0);
+// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
+// cameraPos, lookVec, 5.0);
 
-        assertEquals(pos, result);
-    }
+// assertEquals(pos, result);
+// }
 
-    @Test
-    void findTargetedGhostBlock_LookingAwayFromBlock_ReturnsNull() {
-        Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-        BlockPos pos = new BlockPos(2, 1, 0);
-        BlockState stoneState = Blocks.STONE.getDefaultState();
-        ghostBlocks.put(pos, stoneState);
+// @Test
+// void findTargetedGhostBlock_LookingAwayFromBlock_ReturnsNull() {
+// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
+// BlockPos pos = new BlockPos(2, 1, 0);
+// BlockState stoneState = Blocks.STONE.getDefaultState();
+// ghostBlocks.put(pos, stoneState);
 
-        Vec3d cameraPos = new Vec3d(0, 1, 0);
-        Vec3d lookVec = new Vec3d(-1, 0, 0);
+// Vec3d cameraPos = new Vec3d(0, 1, 0);
+// Vec3d lookVec = new Vec3d(-1, 0, 0);
 
-        BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks, cameraPos, lookVec, 5.0);
+// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
+// cameraPos, lookVec, 5.0);
 
-        assertNull(result);
-    }
+// assertNull(result);
+// }
 
-    @Test
-    void findTargetedGhostBlock_BlockTooFar_ReturnsNull() {
-        Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-        BlockPos pos = new BlockPos(10, 1, 0);
-        BlockState stoneState = Blocks.STONE.getDefaultState();
-        ghostBlocks.put(pos, stoneState);
+// @Test
+// void findTargetedGhostBlock_BlockTooFar_ReturnsNull() {
+// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
+// BlockPos pos = new BlockPos(10, 1, 0);
+// BlockState stoneState = Blocks.STONE.getDefaultState();
+// ghostBlocks.put(pos, stoneState);
 
-        Vec3d cameraPos = new Vec3d(0, 1, 0);
-        Vec3d lookVec = new Vec3d(1, 0, 0);
+// Vec3d cameraPos = new Vec3d(0, 1, 0);
+// Vec3d lookVec = new Vec3d(1, 0, 0);
 
-        BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks, cameraPos, lookVec, 5.0);
+// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
+// cameraPos, lookVec, 5.0);
 
-        assertNull(result);
-    }
+// assertNull(result);
+// }
 
-    @Test
-    void findTargetedGhostBlock_MultipleBlocks_ReturnsClosest() {
-        Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-        BlockPos farPos = new BlockPos(4, 1, 0);
-        BlockPos closePos = new BlockPos(2, 1, 0);
-        BlockState stoneState = Blocks.STONE.getDefaultState();
-        ghostBlocks.put(farPos, stoneState);
-        ghostBlocks.put(closePos, stoneState);
+// @Test
+// void findTargetedGhostBlock_MultipleBlocks_ReturnsClosest() {
+// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
+// BlockPos farPos = new BlockPos(4, 1, 0);
+// BlockPos closePos = new BlockPos(2, 1, 0);
+// BlockState stoneState = Blocks.STONE.getDefaultState();
+// ghostBlocks.put(farPos, stoneState);
+// ghostBlocks.put(closePos, stoneState);
 
-        Vec3d cameraPos = new Vec3d(0, 1, 0);
-        Vec3d lookVec = new Vec3d(1, 0, 0);
+// Vec3d cameraPos = new Vec3d(0, 1, 0);
+// Vec3d lookVec = new Vec3d(1, 0, 0);
 
-        BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks, cameraPos, lookVec, 5.0);
+// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
+// cameraPos, lookVec, 5.0);
 
-        assertEquals(closePos, result);
-    }
+// assertEquals(closePos, result);
+// }
 
-    @Test
-    void pickGhostBlock_CreativeMode_AddsItemToInventory() {
-        when(player.isInCreativeMode()).thenReturn(true);
-        when(inventory.getSlotWithStack(any())).thenReturn(-1);
+// @Test
+// void pickGhostBlock_CreativeMode_AddsItemToInventory() {
+// when(player.isInCreativeMode()).thenReturn(true);
+// when(inventory.getSlotWithStack(any())).thenReturn(-1);
 
-        GhostBlockService.pickGhostBlock(client, state);
+// GhostBlockService.pickGhostBlock(client, state);
 
-        verify(inventory).swapStackWithHotbar(any());
-    }
+// verify(inventory).swapStackWithHotbar(any());
+// }
 
-    @Test
-    void pickGhostBlock_SurvivalModeItemInHotbar_SelectsHotbarSlot() {
-        when(player.isInCreativeMode()).thenReturn(false);
-        when(inventory.getSlotWithStack(any())).thenReturn(2);
+// @Test
+// void pickGhostBlock_SurvivalModeItemInHotbar_SelectsHotbarSlot() {
+// when(player.isInCreativeMode()).thenReturn(false);
+// when(inventory.getSlotWithStack(any())).thenReturn(2);
 
-        GhostBlockService.pickGhostBlock(client, state);
+// GhostBlockService.pickGhostBlock(client, state);
 
-        assertEquals(2, inventory.selectedSlot);
-    }
+// assertEquals(2, inventory.selectedSlot);
+// }
 
-    @Test
-    void pickGhostBlock_SurvivalModeItemInInventory_SwapsWithHotbar() {
-        when(player.isInCreativeMode()).thenReturn(false);
-        when(inventory.getSlotWithStack(any())).thenReturn(15);
+// @Test
+// void pickGhostBlock_SurvivalModeItemInInventory_SwapsWithHotbar() {
+// when(player.isInCreativeMode()).thenReturn(false);
+// when(inventory.getSlotWithStack(any())).thenReturn(15);
 
-        GhostBlockService.pickGhostBlock(client, state);
+// GhostBlockService.pickGhostBlock(client, state);
 
-        verify(inventory).swapSlotWithHotbar(15);
-    }
+// verify(inventory).swapSlotWithHotbar(15);
+// }
 
-    @Test
-    void pickGhostBlock_EmptyStack_NoAction() {
-        BlockState airState = Blocks.AIR.getDefaultState();
+// @Test
+// void pickGhostBlock_EmptyStack_NoAction() {
+// BlockState airState = Blocks.AIR.getDefaultState();
 
-        GhostBlockService.pickGhostBlock(client, airState);
+// GhostBlockService.pickGhostBlock(client, airState);
 
-        verify(inventory, never()).swapStackWithHotbar(any());
-        verify(inventory, never()).swapSlotWithHotbar(anyInt());
-    }
-}
+// verify(inventory, never()).swapStackWithHotbar(any());
+// verify(inventory, never()).swapSlotWithHotbar(anyInt());
+// }
+// }

--- a/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
+++ b/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
@@ -29,6 +29,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.Camera;
 import net.minecraft.entity.player.PlayerInventory;
@@ -39,6 +40,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.network.packet.c2s.play.CreativeInventoryActionC2SPacket;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -67,6 +69,8 @@ class GhostBlockServiceTest {
     private HitResult vanillaTarget;
     @Mock
     private ClientPlayerEntity focusedEntity;
+    @Mock
+    private ClientPlayNetworkHandler networkHandler;
 
     private Map<BlockPos, BlockState> ghostBlocks;
 
@@ -108,7 +112,7 @@ class GhostBlockServiceTest {
         @Test
         void givenNoGhostBlocks_whenPicking_thenNoAction() {
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -121,10 +125,11 @@ class GhostBlockServiceTest {
             when(inventory.getSlotWithStack(stack)).thenReturn(-1);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertTrue(result);
             verify(inventory).swapStackWithHotbar(stack);
+            verify(networkHandler).sendPacket(any(CreativeInventoryActionC2SPacket.class));
         }
 
         @Test
@@ -135,7 +140,7 @@ class GhostBlockServiceTest {
             when(focusedEntity.getRotationVec(1.0f)).thenReturn(new Vec3d(0, 1, 0));
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -146,7 +151,7 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(10, 0, 0), state);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -162,10 +167,11 @@ class GhostBlockServiceTest {
             when(inventory.getSlotWithStack(stack)).thenReturn(-1);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertTrue(result);
             verify(inventory).swapStackWithHotbar(stack);
+            verify(networkHandler).sendPacket(any(CreativeInventoryActionC2SPacket.class));
         }
     }
 
@@ -177,7 +183,7 @@ class GhostBlockServiceTest {
             when(inventory.getSlotWithStack(stack)).thenReturn(0);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertTrue(result);
             assertEquals(0, inventory.selectedSlot);
@@ -191,7 +197,7 @@ class GhostBlockServiceTest {
             when(inventory.getSlotWithStack(stack)).thenReturn(9);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertTrue(result);
             verify(inventory).swapSlotWithHotbar(9);
@@ -206,7 +212,7 @@ class GhostBlockServiceTest {
             ghostBlocks.put(new BlockPos(1, 0, 0), state);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, -1.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertFalse(result);
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -218,7 +224,7 @@ class GhostBlockServiceTest {
             when(stack.isItemEnabled(any())).thenReturn(false);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertTrue(result); // Method still returns true as block was found
             verify(inventory, never()).swapStackWithHotbar(any());
@@ -230,7 +236,7 @@ class GhostBlockServiceTest {
             when(stack.isEmpty()).thenReturn(true);
 
             boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory,
-                    vanillaTarget);
+                    vanillaTarget, networkHandler);
 
             assertTrue(result); // Method still returns true as block was found
             verify(inventory, never()).swapStackWithHotbar(any());

--- a/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
+++ b/src/test/java/mmmfrieddough/craftpilot/service/GhostBlockServiceTest.java
@@ -1,194 +1,231 @@
-// package mmmfrieddough.craftpilot.service;
+package mmmfrieddough.craftpilot.service;
 
-// import static org.junit.jupiter.api.Assertions.assertEquals;
-// import static org.junit.jupiter.api.Assertions.assertNull;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.anyInt;
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-// import java.util.HashMap;
-// import java.util.Map;
+import java.util.HashMap;
+import java.util.Map;
 
-// import org.junit.jupiter.api.BeforeAll;
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.Mock;
-// import org.mockito.junit.jupiter.MockitoExtension;
-// import org.mockito.junit.jupiter.MockitoSettings;
-// import org.mockito.quality.Strictness;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-// import net.minecraft.Bootstrap;
-// import net.minecraft.SharedConstants;
-// import net.minecraft.block.Block;
-// import net.minecraft.block.BlockState;
-// import net.minecraft.block.Blocks;
-// import net.minecraft.client.MinecraftClient;
-// import net.minecraft.client.network.ClientPlayerEntity;
-// import net.minecraft.entity.player.PlayerInventory;
-// import net.minecraft.item.Item;
-// import net.minecraft.item.ItemStack;
-// import net.minecraft.util.math.BlockPos;
-// import net.minecraft.util.math.Vec3d;
-// import net.minecraft.world.World;
+import mmmfrieddough.craftpilot.world.IWorldManager;
+import net.minecraft.Bootstrap;
+import net.minecraft.SharedConstants;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.render.Camera;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 
-// @ExtendWith(MockitoExtension.class)
-// @MockitoSettings(strictness = Strictness.LENIENT)
-// class GhostBlockServiceTest {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GhostBlockServiceTest {
+    @Mock
+    private MinecraftClient client;
+    @Mock
+    private ClientPlayerEntity player;
+    @Mock
+    private PlayerInventory inventory;
+    @Mock
+    private World world;
+    @Mock
+    private BlockState state;
+    @Mock
+    private Block block;
+    @Mock
+    private Item item;
+    @Mock
+    private ItemStack stack = Blocks.DIRT.asItem().getDefaultStack();
+    @Mock
+    private Camera camera;
+    @Mock
+    private IWorldManager worldManager;
 
-// @Mock
-// private MinecraftClient client;
-// @Mock
-// private ClientPlayerEntity player;
-// @Mock
-// private PlayerInventory inventory;
-// @Mock
-// private World world;
-// @Mock
-// private BlockState state;
-// @Mock
-// private Block block;
-// @Mock
-// private Item item;
-// @Mock
-// private ItemStack stack;
+    private Map<BlockPos, BlockState> ghostBlocks;
 
-// @BeforeAll
-// static void init() {
-// SharedConstants.createGameVersion();
-// Bootstrap.initialize();
-// }
+    @BeforeAll
+    static void init() {
+        SharedConstants.createGameVersion();
+        Bootstrap.initialize();
+    }
 
-// @BeforeEach
-// void setUp() {
-// client.player = player;
-// doReturn(inventory).when(player).getInventory();
-// when(player.getWorld()).thenReturn(world);
-// when(world.getEnabledFeatures()).thenReturn(null);
-// when(state.getBlock()).thenReturn(block);
-// when(block.asItem()).thenReturn(item);
-// when(item.getDefaultStack()).thenReturn(stack);
-// when(stack.isEmpty()).thenReturn(false);
-// when(stack.isItemEnabled(any())).thenReturn(true);
-// }
+    @BeforeEach
+    void setUp() {
+        // Basic minecraft setup
+        client.player = player;
+        when(player.getInventory()).thenReturn(inventory);
+        when(player.getWorld()).thenReturn(world);
+        when(world.getEnabledFeatures()).thenReturn(null);
 
-// @Test
-// void pickBlock_EmptyMap_NoAction() {
-// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-// Vec3d cameraPos = new Vec3d(0, 0, 0);
-// Vec3d lookVec = new Vec3d(1, 0, 0);
+        // Block/item chain setup
+        when(state.getBlock()).thenReturn(block);
+        when(block.asItem()).thenReturn(item);
+        when(item.getDefaultStack()).thenReturn(stack);
+        when(stack.isEmpty()).thenReturn(false);
+        when(stack.isItemEnabled(any())).thenReturn(true);
 
-// GhostBlockService.handleGhostBlockPick(client);
+        // Camera setup - looking straight ahead along positive X axis by default
+        when(camera.getPos()).thenReturn(new Vec3d(0, 0, 0));
+        when(camera.getPitch()).thenReturn(0f); // 0 = looking straight ahead
+        when(camera.getYaw()).thenReturn(270f); // 270 = looking along positive X axis
 
-// assertNull(result);
-// }
+        // World manager setup
+        ghostBlocks = new HashMap<>();
+        when(worldManager.getGhostBlocks()).thenReturn(ghostBlocks);
+    }
 
-// @Test
-// void findTargetedGhostBlock_LookingDirectlyAtBlock_ReturnsBlock() {
-// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-// BlockPos pos = new BlockPos(2, 1, 0);
-// BlockState stoneState = Blocks.STONE.getDefaultState();
-// ghostBlocks.put(pos, stoneState);
+    @Nested
+    class BasicPickingTests {
+        @Test
+        void givenNoGhostBlocks_whenPicking_thenNoAction() {
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// Vec3d cameraPos = new Vec3d(0, 1, 0);
-// Vec3d lookVec = new Vec3d(1, 0, 0);
+            assertFalse(result);
+            verify(inventory, never()).swapStackWithHotbar(any());
+            verify(inventory, never()).swapSlotWithHotbar(anyInt());
+        }
 
-// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
-// cameraPos, lookVec, 5.0);
+        @Test
+        void givenGhostBlockInRange_whenLookingAtIt_thenAddsToInventory() {
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
+            when(inventory.getSlotWithStack(stack)).thenReturn(-1);
 
-// assertEquals(pos, result);
-// }
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// @Test
-// void findTargetedGhostBlock_LookingAwayFromBlock_ReturnsNull() {
-// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-// BlockPos pos = new BlockPos(2, 1, 0);
-// BlockState stoneState = Blocks.STONE.getDefaultState();
-// ghostBlocks.put(pos, stoneState);
+            assertTrue(result);
+            verify(inventory).swapStackWithHotbar(stack);
+        }
 
-// Vec3d cameraPos = new Vec3d(0, 1, 0);
-// Vec3d lookVec = new Vec3d(-1, 0, 0);
+        @Test
+        void givenGhostBlock_whenLookingAway_thenNoAction() {
+            ghostBlocks.put(new BlockPos(0, 0, 0), state);
 
-// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
-// cameraPos, lookVec, 5.0);
+            // Looking straight up instead of ahead
+            when(camera.getPitch()).thenReturn(-90f); // -90 = looking straight up
+            when(camera.getYaw()).thenReturn(270f); // yaw doesn't matter when looking straight up
 
-// assertNull(result);
-// }
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// @Test
-// void findTargetedGhostBlock_BlockTooFar_ReturnsNull() {
-// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-// BlockPos pos = new BlockPos(10, 1, 0);
-// BlockState stoneState = Blocks.STONE.getDefaultState();
-// ghostBlocks.put(pos, stoneState);
+            assertFalse(result);
+            verify(inventory, never()).swapStackWithHotbar(any());
+        }
 
-// Vec3d cameraPos = new Vec3d(0, 1, 0);
-// Vec3d lookVec = new Vec3d(1, 0, 0);
+        @Test
+        void givenDistantGhostBlock_whenPicking_thenNoAction() {
+            ghostBlocks.put(new BlockPos(10, 0, 0), state);
 
-// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
-// cameraPos, lookVec, 5.0);
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// assertNull(result);
-// }
+            assertFalse(result);
+            verify(inventory, never()).swapStackWithHotbar(any());
+            verify(inventory, never()).swapSlotWithHotbar(anyInt());
+        }
 
-// @Test
-// void findTargetedGhostBlock_MultipleBlocks_ReturnsClosest() {
-// Map<BlockPos, BlockState> ghostBlocks = new HashMap<>();
-// BlockPos farPos = new BlockPos(4, 1, 0);
-// BlockPos closePos = new BlockPos(2, 1, 0);
-// BlockState stoneState = Blocks.STONE.getDefaultState();
-// ghostBlocks.put(farPos, stoneState);
-// ghostBlocks.put(closePos, stoneState);
+        @Test
+        void givenMultipleBlocks_whenPicking_thenSelectsNearest() {
+            // Blocks along the positive X axis (where we're looking)
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
+            ghostBlocks.put(new BlockPos(2, 0, 0), Blocks.DIRT.getDefaultState());
 
-// Vec3d cameraPos = new Vec3d(0, 1, 0);
-// Vec3d lookVec = new Vec3d(1, 0, 0);
+            when(inventory.getSlotWithStack(stack)).thenReturn(-1);
 
-// BlockPos result = GhostBlockService.findTargetedGhostBlock(ghostBlocks,
-// cameraPos, lookVec, 5.0);
+            boolean result = GhostBlockService.handleGhostBlockPick(worldManager, camera, 5.0, null, true, inventory);
 
-// assertEquals(closePos, result);
-// }
+            assertTrue(result);
+            verify(inventory).swapStackWithHotbar(stack);
+        }
+    }
 
-// @Test
-// void pickGhostBlock_CreativeMode_AddsItemToInventory() {
-// when(player.isInCreativeMode()).thenReturn(true);
-// when(inventory.getSlotWithStack(any())).thenReturn(-1);
+    @Nested
+    class InventoryManagementTests {
+        @Test
+        void givenItemInHotbar_whenInSurvivalMode_thenSelectsHotbarSlot() {
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
+            when(inventory.getSlotWithStack(stack)).thenReturn(0);
 
-// GhostBlockService.pickGhostBlock(client, state);
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// verify(inventory).swapStackWithHotbar(any());
-// }
+            assertTrue(result);
+            assertEquals(0, inventory.selectedSlot);
+            verify(inventory, never()).swapStackWithHotbar(any());
+            verify(inventory, never()).swapSlotWithHotbar(anyInt());
+        }
 
-// @Test
-// void pickGhostBlock_SurvivalModeItemInHotbar_SelectsHotbarSlot() {
-// when(player.isInCreativeMode()).thenReturn(false);
-// when(inventory.getSlotWithStack(any())).thenReturn(2);
+        @Test
+        void givenItemInInventory_whenInSurvivalMode_thenSwapsWithHotbar() {
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
+            when(inventory.getSlotWithStack(stack)).thenReturn(9);
 
-// GhostBlockService.pickGhostBlock(client, state);
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// assertEquals(2, inventory.selectedSlot);
-// }
+            assertTrue(result);
+            verify(inventory).swapSlotWithHotbar(9);
+            verify(inventory, never()).swapStackWithHotbar(any());
+        }
+    }
 
-// @Test
-// void pickGhostBlock_SurvivalModeItemInInventory_SwapsWithHotbar() {
-// when(player.isInCreativeMode()).thenReturn(false);
-// when(inventory.getSlotWithStack(any())).thenReturn(15);
+    @Nested
+    class EdgeCaseTests {
+        @Test
+        void givenNegativeReach_whenPicking_thenNoAction() {
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
 
-// GhostBlockService.pickGhostBlock(client, state);
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, -1.0, null, true, inventory);
 
-// verify(inventory).swapSlotWithHotbar(15);
-// }
+            assertFalse(result);
+            verify(inventory, never()).swapStackWithHotbar(any());
+        }
 
-// @Test
-// void pickGhostBlock_EmptyStack_NoAction() {
-// BlockState airState = Blocks.AIR.getDefaultState();
+        @Test
+        void givenDisabledItem_whenPicking_thenNoAction() {
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
+            when(stack.isItemEnabled(any())).thenReturn(false);
 
-// GhostBlockService.pickGhostBlock(client, airState);
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
 
-// verify(inventory, never()).swapStackWithHotbar(any());
-// verify(inventory, never()).swapSlotWithHotbar(anyInt());
-// }
-// }
+            assertTrue(result); // Method still returns true as block was found
+            verify(inventory, never()).swapStackWithHotbar(any());
+        }
+
+        @Test
+        void givenEmptyItemStack_whenPicking_thenNoAction() {
+            ghostBlocks.put(new BlockPos(1, 0, 0), state);
+            when(stack.isEmpty()).thenReturn(true);
+
+            boolean result = GhostBlockService.handleGhostBlockPick(
+                    worldManager, camera, 5.0, null, true, inventory);
+
+            assertTrue(result); // Method still returns true as block was found
+            verify(inventory, never()).swapStackWithHotbar(any());
+        }
+    }
+}


### PR DESCRIPTION
Many bug fixes and improvements to block outlines and pick block.

Block outlines:

- Add highlighting of targeted suggestion block
- Make outline colors configurable
- Fix vanilla block outlines still appearing when looking through a suggestion block
- Fix z fighting between vanilla and suggestion block outlines

Pick block:

- Fix selecting vanilla block behind targeted suggestion block
- Fix selecting suggestion block behind targeted vanilla block
- Fix getting block in creative not updating on the server side

Also improves rendering performance by reducing duplicate calculations for the targeted block.